### PR TITLE
Made a workaround for moving a method.

### DIFF
--- a/Subproject2/1. SOVA/Controllers/QuestionsController.cs
+++ b/Subproject2/1. SOVA/Controllers/QuestionsController.cs
@@ -47,7 +47,7 @@ namespace _1._SOVA.Controllers
         [HttpGet("{questionId}/answers", Name = nameof(GetAnswersForQuestion))]
         public ActionResult GetAnswersForQuestion([FromQuery] PagingAttributes pagingAttributes, int questionId)
         {
-            var answers = _answerRepository.GetAnswersForQuestionById(questionId, pagingAttributes);
+            var answers = _answerRepository.GetAnswersForQuestionById(questionId, pagingAttributes); // workaround
             return Ok(CreateResult(answers, questionId, pagingAttributes));
         }
 
@@ -102,7 +102,7 @@ namespace _1._SOVA.Controllers
 
         private object CreateResult(IEnumerable<Answer> answers, int questionId, PagingAttributes attr)
         {
-            var totalItems = _questionRepository.NoOfAnswers(questionId);
+            var totalItems = _answerRepository.NoOfAnswers(questionId); // workaround
             var numberOfPages = Math.Ceiling((double)totalItems / attr.PageSize);
 
             var prev = attr.Page > 0

--- a/Subproject2/1. SOVA/Controllers/QuestionsController.cs
+++ b/Subproject2/1. SOVA/Controllers/QuestionsController.cs
@@ -16,10 +16,14 @@ namespace _1._SOVA.Controllers
         private readonly IQuestionRepository _questionRepository;
         private IMapper _mapper;
 
-        public QuestionsController(IQuestionRepository questionRepository, IMapper mapper)
+        private readonly IAnswerRepository _answerRepository; // this should not exist in this controller, it is a workaround
+
+        public QuestionsController(IQuestionRepository questionRepository, IMapper mapper, IAnswerRepository answerRepository) // workaround
         {
             _questionRepository = questionRepository;
             _mapper = mapper;
+
+            _answerRepository = answerRepository; //workaround
         }
 
         [HttpGet(Name = nameof(GetQuestions))]
@@ -43,7 +47,7 @@ namespace _1._SOVA.Controllers
         [HttpGet("{questionId}/answers", Name = nameof(GetAnswersForQuestion))]
         public ActionResult GetAnswersForQuestion([FromQuery] PagingAttributes pagingAttributes, int questionId)
         {
-            var answers = _questionRepository.GetAnswersForQuestionById(questionId, pagingAttributes);
+            var answers = _answerRepository.GetAnswersForQuestionById(questionId, pagingAttributes);
             return Ok(CreateResult(answers, questionId, pagingAttributes));
         }
 

--- a/Subproject2/2. Data Layer Abstractions/IAnswerRepository.cs
+++ b/Subproject2/2. Data Layer Abstractions/IAnswerRepository.cs
@@ -10,5 +10,7 @@ namespace _2._Data_Layer_Abstractions
         Answer GetAnswerById(int answerId);
 
         IEnumerable<Answer> GetAnswersForQuestionById(int questionId, PagingAttributes pagingAttributes);
+
+        int NoOfAnswers(int questionId);
     }
 }

--- a/Subproject2/2. Data Layer Abstractions/IAnswerRepository.cs
+++ b/Subproject2/2. Data Layer Abstractions/IAnswerRepository.cs
@@ -8,5 +8,7 @@ namespace _2._Data_Layer_Abstractions
     public interface IAnswerRepository
     {
         Answer GetAnswerById(int answerId);
+
+        IEnumerable<Answer> GetAnswersForQuestionById(int questionId, PagingAttributes pagingAttributes);
     }
 }

--- a/Subproject2/2. Data Layer Abstractions/IQuestionRepository.cs
+++ b/Subproject2/2. Data Layer Abstractions/IQuestionRepository.cs
@@ -9,7 +9,6 @@ namespace _2._Data_Layer_Abstractions
     {
         int NoOfResults(string queryString);
         int NoOfAnswers(int questionId);
-        IEnumerable<Answer> GetAnswersForQuestionById(int questionId, PagingAttributes pagingAttributes);
         IEnumerable<Question> GetTenRandomQuestions();
         Question GetById(int submissionId);
         IEnumerable<SearchResult> SearchQuestions(string queryString, PagingAttributes pagingAttributes);

--- a/Subproject2/2. Data Layer Abstractions/IQuestionRepository.cs
+++ b/Subproject2/2. Data Layer Abstractions/IQuestionRepository.cs
@@ -8,7 +8,6 @@ namespace _2._Data_Layer_Abstractions
     public interface IQuestionRepository
     {
         int NoOfResults(string queryString);
-        int NoOfAnswers(int questionId);
         IEnumerable<Question> GetTenRandomQuestions();
         Question GetById(int submissionId);
         IEnumerable<SearchResult> SearchQuestions(string queryString, PagingAttributes pagingAttributes);

--- a/Subproject2/3. Data Layer/AnswerRepository.cs
+++ b/Subproject2/3. Data Layer/AnswerRepository.cs
@@ -32,5 +32,12 @@ namespace _3._Data_Layer
                 .Take(pagingAttributes.PageSize)
                 .ToList();
         }
+
+        public int NoOfAnswers(int questionId)
+        {
+            return _databaseContext.Answers
+                .Include(a => a.Submission)
+                .Count(a => a.ParentId == questionId);
+        }
     }
 }

--- a/Subproject2/3. Data Layer/AnswerRepository.cs
+++ b/Subproject2/3. Data Layer/AnswerRepository.cs
@@ -22,5 +22,15 @@ namespace _3._Data_Layer
         {
             return _databaseContext.Answers.Include(a => a.Submission).FirstOrDefault(a => a.SubmissionId == answerId);
         }
+
+        public IEnumerable<Answer> GetAnswersForQuestionById(int questionId, PagingAttributes pagingAttributes)
+        {
+            return _databaseContext.Answers
+                .Include(a => a.Submission)
+                .Where(a => a.ParentId == questionId)
+                .Skip(pagingAttributes.Page * pagingAttributes.PageSize)
+                .Take(pagingAttributes.PageSize)
+                .ToList();
+        }
     }
 }

--- a/Subproject2/3. Data Layer/QuestionRepository.cs
+++ b/Subproject2/3. Data Layer/QuestionRepository.cs
@@ -44,12 +44,5 @@ namespace _3._Data_Layer
             return _databaseContext.SearchResults.FromSqlRaw("SELECT * from best_match_weighted({0})", queryString)
                 .Count();
         }
-
-        public int NoOfAnswers(int questionId)
-        {
-            return _databaseContext.Answers
-                .Include(a => a.Submission)
-                .Count(a => a.ParentId == questionId);
-        }
     }
 }

--- a/Subproject2/3. Data Layer/QuestionRepository.cs
+++ b/Subproject2/3. Data Layer/QuestionRepository.cs
@@ -31,17 +31,6 @@ namespace _3._Data_Layer
             return _databaseContext.Questions.Find(submissionId);
         }
 
-
-        public IEnumerable<Answer> GetAnswersForQuestionById(int questionId, PagingAttributes pagingAttributes)
-        {
-            return _databaseContext.Answers
-                .Include(a => a.Submission)
-                .Where(a => a.ParentId == questionId)
-                .Skip(pagingAttributes.Page * pagingAttributes.PageSize)
-                .Take(pagingAttributes.PageSize)
-                .ToList();
-        }
-
         public IEnumerable<SearchResult> SearchQuestions(string queryString, PagingAttributes pagingAttributes)
         {
             return _databaseContext.SearchResults.FromSqlRaw("SELECT * from best_match_weighted({0})", queryString)

--- a/Subproject2/Tests/DataServiceTests.cs
+++ b/Subproject2/Tests/DataServiceTests.cs
@@ -241,6 +241,16 @@ namespace Tests
         }
 
         [Fact]
+        public void GetAnswersByQuestionId_ValidArgument()
+        {
+            // Arrange
+            int questionId = 19;
+
+            // Act
+            
+        }
+
+        [Fact]
         public void GetNumberOfCommentsOnSubmission_ValidArgument()
         {
             // Arrange
@@ -401,7 +411,5 @@ namespace Tests
             // Assert
             Assert.NotNull(linkPost.LinkedPost.Submission);
         }
-
-
     }
 }


### PR DESCRIPTION
The method in question should be in the answers repository, however it was referenced by the questions controller as well, so I was forced to make a temporary workaround by adding the answers repository to the controller's constructor.

The controller no longer needs to contain the endpoint for fetching answers, since the answers will be included in the data upon fetching questions.