### PR TITLE
get more questions with pagination on hoempage

### DIFF
--- a/Subproject2/1. SOVA/Controllers/QuestionsController.cs
+++ b/Subproject2/1. SOVA/Controllers/QuestionsController.cs
@@ -33,8 +33,8 @@ namespace _1._SOVA.Controllers
             return Ok(CreateResult(questions, pagingAttributes));
         }
 
-        [HttpGet("{questionId}", Name = nameof(GetQuestion))]
-        public ActionResult GetQuestion(int questionId)
+        [HttpGet("{questionId}", Name = nameof(GetQuestionById))]
+        public ActionResult GetQuestionById(int questionId)
         {
             var question = _questionRepository.GetById(questionId);
             if (question == null)
@@ -79,7 +79,7 @@ namespace _1._SOVA.Controllers
         {
             var dto = _mapper.Map<QuestionDto>(question);
             dto.Link = Url.Link(
-                    nameof(GetQuestion),
+                    nameof(GetQuestionById),
                     new { questionId = question.SubmissionId });
             return dto;
         }

--- a/Subproject2/2. Data Layer Abstractions/IQuestionRepository.cs
+++ b/Subproject2/2. Data Layer Abstractions/IQuestionRepository.cs
@@ -8,8 +8,9 @@ namespace _2._Data_Layer_Abstractions
 {
     public interface IQuestionRepository
     {
+        int NoOfRandomQuestions();
         int NoOfResults(string queryString, int? userId);
-        IEnumerable<Question> GetTenRandomQuestions();
+        IEnumerable<Question> GetQuestions(PagingAttributes pagingAttributes);
         Question GetById(int submissionId);
         IEnumerable<SearchResult> SearchQuestions(string queryString, int? userId, PagingAttributes pagingAttributes);
         List<QuestionsTag> GetQuestionsByTags(string tagName, PagingAttributes pagingAttributes);

--- a/Subproject2/3. Data Layer/QuestionRepository.cs
+++ b/Subproject2/3. Data Layer/QuestionRepository.cs
@@ -20,10 +20,12 @@ namespace _3._Data_Layer
             _databaseContext = databaseContext;
         }
 
-        public IEnumerable<Question> GetTenRandomQuestions()
+        public IEnumerable<Question> GetQuestions(PagingAttributes pagingAttributes)
         {
             var randomOffSet = new Random().Next(1, 1000);
-            return _databaseContext.Questions.Skip(randomOffSet).Take(10);
+            return _databaseContext.Questions.Skip(randomOffSet).Skip(pagingAttributes.Page * pagingAttributes.PageSize)
+                .Take(pagingAttributes.PageSize)
+                .ToList();
         }
 
         public Question GetById(int submissionId)
@@ -57,6 +59,12 @@ namespace _3._Data_Layer
                 return 0;
             return _databaseContext.SearchResults.FromSqlRaw("SELECT * from best_match_weighted({0}, {1})", userId, queryString)
                 .Count();
+        }
+
+        public int NoOfRandomQuestions()
+        {
+            var randomOffSet = new Random().Next(1, 1000);
+            return _databaseContext.Questions.Skip(randomOffSet).Count();
         }
     }
 }


### PR DESCRIPTION
On the homepage (or `/api/questions` to be technical), instead of getting only 10 random questions, we get a lot more questions randomly but with pagination with limit 10