### PR TITLE
Refresh stays on the same page

### DIFF
--- a/Subproject2/SOVA/Controllers/MarkingsController.cs
+++ b/Subproject2/SOVA/Controllers/MarkingsController.cs
@@ -55,6 +55,21 @@ namespace SOVA.Controllers
             return Ok(new { message = $"Successfully bookmarked. Submission with id {submissionId} is now bookmarked." });
         }
 
+        [Authorize]
+        [HttpGet("{submissionId}/checkIfBookmarked")]
+        public ActionResult checkBookmark(int submissionId)
+        {
+            var userId = int.TryParse(HttpContext.User.Identity.Name, out var id) ? id : 1;
+            if (_markingRepository.IsMarked(submissionId, userId))
+            {
+                return Ok(new { message = "Already bookmarked." });
+            }
+            else
+            {
+                return Ok(new { message = "Not bookmarked." });
+            }
+        }
+
         ///////////////////
         //
         // Helpers

--- a/Subproject2/SOVA/wwwroot/index.html
+++ b/Subproject2/SOVA/wwwroot/index.html
@@ -13,11 +13,10 @@
 </head>
 <body>
     <div class="header-border">
-        <a href="https://localhost:5001/">
-            <img src="assets/images/stack-overflow-raw4.png"
-                 class="header-image"
-                 alt="SOVA by raw4" />
-        </a>
+        <img src="assets/images/stack-overflow-raw4.png"
+             class="header-image"
+             alt="SOVA by raw4"
+             data-bind="click: goToLandingPage" />
     </div>
     <nav-bar></nav-bar>
     <div data-bind="component: {name: activeComponent, params: activeParams}"></div>

--- a/Subproject2/SOVA/wwwroot/js/app.js
+++ b/Subproject2/SOVA/wwwroot/js/app.js
@@ -1,5 +1,5 @@
 ﻿define(["knockout", "store"], function (ko, store) {
-    var activeComponent = ko.observable("landing-page");
+    var activeComponent = !!localStorage.getItem("activeComponent") ? ko.observable(localStorage.getItem("activeComponent")) : ko.observable("landing-page");
     var activeParams = ko.observable({});
 
     var changeContent = function (questionId) {
@@ -10,10 +10,16 @@
         activeComponent(store.getState().activeComponent);
     });
 
+    goToLandingPage = () => {
+        localStorage.setItem("activeComponent", "landing-page");
+        store.dispatch(store.actions.landingPage());
+    }
+
 
     return {
         activeComponent,
         activeParams,
         changeContent,
+        goToLandingPage
     };
 });

--- a/Subproject2/SOVA/wwwroot/js/components/individual-answer/individual-answer.js
+++ b/Subproject2/SOVA/wwwroot/js/components/individual-answer/individual-answer.js
@@ -1,5 +1,4 @@
 ﻿define(['knockout', 'dataService', 'store'], function (ko, ds, store) {
-    var activeComponent = ko.observable("individual-answer");
     var selectedAnswerId = ko.observable(store.getState().selectedPostId);
     var answerById = ko.observable();
 
@@ -15,7 +14,6 @@
         return {
             selectedAnswerId,
             answerById,
-            activeComponent
         };
     };
 });

--- a/Subproject2/SOVA/wwwroot/js/components/landing-page/landing-page.js
+++ b/Subproject2/SOVA/wwwroot/js/components/landing-page/landing-page.js
@@ -1,5 +1,4 @@
 ﻿define(['knockout', 'dataService', 'store'], function (ko, ds, store) {
-    var activeComponent = ko.observable("landing-page");
     var questions = ko.observableArray([]);
     var sessionStorage = ko.observable(localStorage.getItem("username"));
 
@@ -21,7 +20,6 @@
     }
     return function () {
         return {
-            activeComponent,
             questions,
             selectQuestion,
             selectQuestionsByTag,

--- a/Subproject2/SOVA/wwwroot/js/components/login-page/login-page.js
+++ b/Subproject2/SOVA/wwwroot/js/components/login-page/login-page.js
@@ -1,12 +1,14 @@
 ﻿define(["knockout", "dataService", "store"], function (ko, ds, store) {
 
-    var activeComponent = ko.observable("login-page");
     var errorMessage = ko.observable();
     var username = ko.observable();
     var password = ko.observable();
     var message = ko.observable(store.getState().optionalMessage);
 
     store.subscribe(function () {
+        username(null);
+        password(null);
+        errorMessage(null);
         message(store.getState().optionalMessage);
     });
 
@@ -29,7 +31,6 @@
 
     return function () {
         return {
-            activeComponent,
             login,
             errorMessage,
             username,

--- a/Subproject2/SOVA/wwwroot/js/components/nav-bar/nav-bar.js
+++ b/Subproject2/SOVA/wwwroot/js/components/nav-bar/nav-bar.js
@@ -1,12 +1,15 @@
 ﻿define(["knockout", "store", "dataService"], function (ko, store, ds) {
     return function () {
-        var activeComponent = ko.observable(store.getState().activeComponent);
+        var activeComponentInLocalStorage = localStorage.getItem("activeComponent");
+
+        var activeComponent = !!activeComponentInLocalStorage ? ko.observable(activeComponentInLocalStorage) : ko.observable(store.getState().activeComponent);
 
         var currentUser = ko.observable(localStorage.getItem("username"));
         var authenticationToken = ko.observable(store.getState().token);
         var queryTerm = ko.observable();
 
         var search = function () {
+            localStorage.setItem("searchTerm", queryTerm());
             store.dispatch(store.actions.searching(queryTerm()));
         };
 

--- a/Subproject2/SOVA/wwwroot/js/components/question-with-answers/question-with-answers.html
+++ b/Subproject2/SOVA/wwwroot/js/components/question-with-answers/question-with-answers.html
@@ -4,7 +4,6 @@
             <div class="border-bottom border-dark mb-2" style="width: 100%">
                 <div class="mb-2">
                     <h2 class="question-title" data-bind="text: title"></h2>
-
                     <div data-bind="with: answers.$values[0]">
                         <div data-bind="if: question">
                             <div class="row pl-3" data-bind="foreach: question.questionsTags.$values">
@@ -27,10 +26,10 @@
                     </div>
                     <span>votes</span>
                     <div class="d-flex justify-content-center" data-bind="if: $parent.isBookmarked() === false">
-                        <span style="font-size: 30px; cursor: pointer;" data-bind="click: $parent.toggleBookmark">☆</span>
+                        <span style="font-size: 30px; cursor: pointer; user-select: none;" data-bind="click: $parent.toggleBookmark">☆</span>
                     </div>
                     <div class="d-flex justify-content-center" data-bind="if: $parent.isBookmarked() === true">
-                        <span style="font-size: 24px; cursor: pointer; margin-top: 4px;" data-bind="if: $parent.isBookmarked() === true, click: $parent.toggleBookmark">⭐</span>
+                        <span style="font-size: 24px; cursor: pointer; margin-top: 4px; user-select: none;" data-bind="if: $parent.isBookmarked() === true, click: $parent.toggleBookmark">⭐</span>
                     </div>
                 </div>
 

--- a/Subproject2/SOVA/wwwroot/js/components/question-with-answers/question-with-answers.js
+++ b/Subproject2/SOVA/wwwroot/js/components/question-with-answers/question-with-answers.js
@@ -1,6 +1,5 @@
 ﻿define(['knockout', 'dataService', 'store'], function (ko, ds, store) {
     return function () {
-        var activeComponent = ko.observable("question-with-answers");
         var selectedQuestionId = ko.observable(store.getState().selectedQuestionId);
         var showAnnotations = ko.observable(false);
         var textAreaValue = ko.observable();
@@ -92,7 +91,6 @@
 
         return {
             selectedQuestionId,
-            activeComponent,
             questionByIdWithAnswers,
             selectQuestionsByTag,
             showAnnotations,

--- a/Subproject2/SOVA/wwwroot/js/components/question-with-answers/question-with-answers.js
+++ b/Subproject2/SOVA/wwwroot/js/components/question-with-answers/question-with-answers.js
@@ -26,6 +26,14 @@
             questionByIdWithAnswers(data);
         });
 
+        ds.checkIfBookmarked((data) => {
+            if (data.message.toLowerCase().includes("not bookmarked")) {
+                isBookmarked(false);
+            } else if (data.message.toLowerCase().includes("already bookmarked")) {
+                isBookmarked(true);
+            }
+        })
+
         ds.getAnnotation((data) => {
             if (data.message && data.message.toLowerCase().includes("not found")) {
                 annotationText(null);

--- a/Subproject2/SOVA/wwwroot/js/components/signup-page/signup-page.js
+++ b/Subproject2/SOVA/wwwroot/js/components/signup-page/signup-page.js
@@ -1,7 +1,5 @@
 ﻿define(['knockout', 'dataService', 'store'], function (ko, ds, store) {
     return function () {
-
-        var activeComponent = ko.observable("signup-page");
         var errorMessage = ko.observable();
         var username = ko.observable();
         var password = ko.observable();
@@ -19,7 +17,6 @@
             });
         }
         return {
-            activeComponent,
             createUser,
             errorMessage,
             username,

--- a/Subproject2/SOVA/wwwroot/js/components/tag-filter/tag-filter.js
+++ b/Subproject2/SOVA/wwwroot/js/components/tag-filter/tag-filter.js
@@ -1,5 +1,4 @@
 ﻿define(['knockout', 'dataService', 'store'], function (ko, ds, store) {
-    var activeComponent = ko.observable("tag-filter");
     var questionsByTag = ko.observable();
     var selectedTag = ko.observable(store.getState().selectedTag);
     var prevPage = ko.observable();
@@ -42,7 +41,6 @@
 
     return function () {
         return {
-            activeComponent,
             selectQuestion,
             selectedTag,
             questionsByTag,

--- a/Subproject2/SOVA/wwwroot/js/services/dataService.js
+++ b/Subproject2/SOVA/wwwroot/js/services/dataService.js
@@ -3,11 +3,12 @@
     var selectedQuestionIdInLocalStorage = localStorage.getItem("selectedQuestionId");
     var searchTermInLocalStorage = localStorage.getItem("searchTerm");
     var selectedTagInLocalStorage = localStorage.getItem("selectedTag");
+    var authenticationTokenInLocalStorage = localStorage.getItem("token");
 
     var selectedQuestionId = !!selectedQuestionIdInLocalStorage ? ko.observable(selectedQuestionIdInLocalStorage) : ko.observable(store.getState().selectedQuestionId);
     var selectedPostId = ko.observable(store.getState().selectedPostId);
     var selectedTag = !!selectedTagInLocalStorage ? ko.observable(selectedTagInLocalStorage) : ko.observable(store.getState().selectedTag);
-    var authenticationToken = ko.observable();
+    var authenticationToken = !!authenticationTokenInLocalStorage ? ko.observable(`Bearer ${localStorage.getItem('token')}`) : ko.observable();
     var searchTerm = !!searchTermInLocalStorage ? ko.observable(searchTermInLocalStorage) : ko.observable();
 
     store.subscribe(function () {
@@ -122,10 +123,25 @@
         if (!localStorage.getItem('token')) {
             callback({ message: "Not authorized" });
         } else {
-
             var response = await fetch(`api/${selectedQuestionId()}/bookmarks`,
                 {
                     method: "PUT",
+                    headers: {
+                        "Authorization": `${authenticationToken()}`
+                    }
+                });
+            var data = await response.json();
+            callback(data);
+        }
+    }
+
+    var checkIfBookmarked = async (callback) => {
+        if (!localStorage.getItem('token')) {
+            callback({ message: "Not authorized" });
+        } else {
+            var response = await fetch(`api/${selectedQuestionId()}/checkIfBookmarked`,
+                {
+                    method: "GET",
                     headers: {
                         "Authorization": `${authenticationToken()}`
                     }
@@ -150,6 +166,7 @@
         moreQuestions,
         saveAnnotation,
         getAnnotation,
-        toggleBookmarkStatus
+        toggleBookmarkStatus,
+        checkIfBookmarked
     };
 });

--- a/Subproject2/SOVA/wwwroot/js/services/dataService.js
+++ b/Subproject2/SOVA/wwwroot/js/services/dataService.js
@@ -1,10 +1,14 @@
 ﻿define(['knockout', 'store'], function (ko, store) {
 
-    var selectedQuestionId = ko.observable(store.getState().selectedQuestionId);
+    var selectedQuestionIdInLocalStorage = localStorage.getItem("selectedQuestionId");
+    var searchTermInLocalStorage = localStorage.getItem("searchTerm");
+    var selectedTagInLocalStorage = localStorage.getItem("selectedTag");
+
+    var selectedQuestionId = !!selectedQuestionIdInLocalStorage ? ko.observable(selectedQuestionIdInLocalStorage) : ko.observable(store.getState().selectedQuestionId);
     var selectedPostId = ko.observable(store.getState().selectedPostId);
-    var selectedTag = ko.observable(store.getState().selectedTag);
+    var selectedTag = !!selectedTagInLocalStorage ? ko.observable(selectedTagInLocalStorage) : ko.observable(store.getState().selectedTag);
     var authenticationToken = ko.observable();
-    var searchTerm = ko.observable();
+    var searchTerm = !!searchTermInLocalStorage ? ko.observable(searchTermInLocalStorage) : ko.observable();
 
     store.subscribe(function () {
         authenticationToken(`Bearer ${localStorage.getItem('token')}`);

--- a/Subproject2/SOVA/wwwroot/js/services/store.js
+++ b/Subproject2/SOVA/wwwroot/js/services/store.js
@@ -22,18 +22,25 @@
     };
 
     var reducer = function (state, action) {
+        localStorage.setItem("activeComponent", action.activeComponent)
         switch (action.type) {
             case landingPage:
                 return Object.assign({}, state, { activeComponent: action.activeComponent, username: action.username });
             case tagFilter:
+                localStorage.setItem("selectedTag", action.selectedTag);
                 return Object.assign({}, state, { activeComponent: action.activeComponent, selectedTag: action.selectedTag });
             case answerPage:
+                localStorage.setItem("selectedPostId", action.selectedPostId);
                 return Object.assign({}, state, { selectedPostId: action.selectedPostId, activeComponent: action.activeComponent });
             case selectQuestion:
+                localStorage.setItem("selectedQuestionId", action.selectedQuestionId);
                 return Object.assign({}, state, { selectedQuestionId: action.selectedQuestionId, activeComponent: action.activeComponent });
             case login:
                 return Object.assign({}, state, { activeComponent: action.activeComponent, optionalMessage: action.optionalMessage });
             case selectPost:
+                localStorage.setItem("selectedQuestionId", action.selectedQuestionId);
+                localStorage.setItem("selectedPostId", action.selectedPostId);
+                localStorage.setItem("isQuestion", action.isQuestion);
                 return Object.assign({}, state, { selectedQuestionId: action.selectedQuestionId, selectedPostId: action.selectedPostId, isQuestion: action.isQuestion, activeComponent: action.activeComponent });
             case signupUser:
                 return Object.assign({}, state, { activeComponent: action.activeComponent });


### PR DESCRIPTION
When you refresh, it reloads the same page rather than going to the landing page.
- How we achieve this is by the extensive use of local storage. (We save all the tags, question id, search text in local storage.)

### Better practice would have been to use the query params to stay on the same page on reload, but we lack the knowledge and time to do so. Localstorage it is for now.
Query params example --> `https://stackoverflow.com/questions/59333622/throttling-requests-with-redux-saga`